### PR TITLE
Implemented Send Message tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Usage
 BullyCPP has both a command-line and a GUI mode.
 Running it with no arguments will launch the GUI.
 
+#### GUI mode
+GUI Mode provides a visual interaction interface with BullyCPP.
+Serial text is displayed in the large text area centered in the GUI. Typing directly in the serial text area will send individual characters as typed.
+
+**Send Message:**
+Used to send a string over the serial port. BullyCPP will automatically append a new-line character (\n) to the end of the string before sending. To omit this, hold down CONTROL when either clicking SEND or pressing ENTER (if enabled).
+
+**Target Programming:**
+Used to transmit a .hex file over serial. Select the program file with OPEN... and send the data via PROGRAM. Enable "MCLR before programming" to send a MCLR over serial before sending the program file.
+
+**Use µC/PC Variables:**
+Used to view variables with serial.
+
+#### Command-line mode
 For advanced usage, you may wish to run it without the interface.
 You must use the `--no-gui` option, the device name, and the name of an Intel hex file (emitted by MPLAB) you want to flash:
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -151,7 +151,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 #endif
 
 	// Set the monospace font for the send message TextBox
-	ui->sendMsg_TextBox->setFont(std::move(monoFont));
+	ui->sendMsg_TextBox->setFont(monoFont);
 }
 
 MainWindow::~MainWindow()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -114,7 +114,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	// The "Monospace" suggestion won't work on Windows, which is what the StyleHint is for.
 	QFont monoFont("Monospace");
 	monoFont.setStyleHint(QFont::TypeWriter);
-	ui->serialText->setFont(std::move(monoFont));
+    ui->serialText->setFont(std::move(monoFont));
 
 	// Set up the serial port combo box.
 	// We would like to refresh every 5 seconds (or so).
@@ -149,6 +149,9 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	if(settings.value(AUTO_UPDATE_KEY, true).toBool())
 		checker.checkForUpdate();
 #endif
+
+    // Set the monospace font for the send message TextBox
+    ui->sendMsg_TextBox->setFont(std::move(monoFont));
 }
 
 MainWindow::~MainWindow()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -57,7 +57,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	connect(ui->hexFileNameEdit, &QLineEdit::textChanged, this, &MainWindow::onHexFileTextChanged);
 	connect(ui->hexFileNameEdit, &QLineEdit::textChanged, this, &MainWindow::saveHexFilePref);
 	connect(this, &MainWindow::programHexFile,
-			picDriver, static_cast<void (QtPicDriver::*)(QString)>(&QtPicDriver::programHexFile));
+	        picDriver, static_cast<void (QtPicDriver::*)(QString)>(&QtPicDriver::programHexFile));
 	connect(picDriver, &QtPicDriver::deviceChanged, ui->deviceInfoLabel, &QLabel::setText);
 	connect(picDriver, &QtPicDriver::programmingStateChanged, ui->progressWidget, &QWidget::setVisible);
 	connect(picDriver, &QtPicDriver::programmingStateChanged, ui->programmingWidget, &QWidget::setHidden);
@@ -124,7 +124,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	QList<qint32> bauds = QSerialPortInfo::standardBaudRates();
 	QStringList baudStrings;
 	std::transform(begin(bauds), end(bauds), std::back_inserter(baudStrings),
-				   [](qint32 baud){ QString s; s.setNum(baud); return s; });
+	               [](qint32 baud){ QString s; s.setNum(baud); return s; });
 	// Baud is always set in parser (default option is present).
 	// Because of this fact, it is difficult to determine the "most wanted"
 	// value, so we don't save this one.
@@ -261,21 +261,21 @@ void MainWindow::refreshSerialPortsKeepCurrent()
 void MainWindow::showAbout()
 {
 	QMessageBox aboutBox(QMessageBox::NoIcon,
-						 QStringLiteral("About BullyCPP"),
-						 "<p align='center'>"
-						 "<h2>BullyCPP " VERSION_STRING "</h2><br>"
-						 "Copyright &#0169; 2014 - 2015 George Hilliard (\"thirtythreeforty\") and contributors"
-						 "<p align='center'>"
-						 "See <a href='https://www.github.com/thirtythreeforty/bullycpp'>www.github.com/thirtythreeforty/bullycpp</a> "
-						 "for updates and source code."
-						 "<p>"
-						 "BullyCPP is a serial console and a driver for the open source Bully Bootloader for the PIC24 and dsPIC33.  "
-						 "See <a href='http://www.reesemicro.com/'>www.reesemicro.com</a> for the microcontroller firmware."
-						 "<p>"
-						 "This program is free software; you can redistribute it and/or modify it under the terms of "
-						 "the GNU General Public License v3 or later, as published by the Free Software Foundation.",
-						 QMessageBox::Ok,
-						 this
+	                     QStringLiteral("About BullyCPP"),
+	                     "<p align='center'>"
+	                     "<h2>BullyCPP " VERSION_STRING "</h2><br>"
+	                     "Copyright &#0169; 2014 - 2015 George Hilliard (\"thirtythreeforty\") and contributors"
+	                     "<p align='center'>"
+	                     "See <a href='https://www.github.com/thirtythreeforty/bullycpp'>www.github.com/thirtythreeforty/bullycpp</a> "
+	                     "for updates and source code."
+	                     "<p>"
+	                     "BullyCPP is a serial console and a driver for the open source Bully Bootloader for the PIC24 and dsPIC33.  "
+	                     "See <a href='http://www.reesemicro.com/'>www.reesemicro.com</a> for the microcontroller firmware."
+	                     "<p>"
+	                     "This program is free software; you can redistribute it and/or modify it under the terms of "
+	                     "the GNU General Public License v3 or later, as published by the Free Software Foundation.",
+	                     QMessageBox::Ok,
+	                     this
 	);
 
 	aboutBox.setIconPixmap(appIcon.pixmap(128, 128));
@@ -342,7 +342,7 @@ void MainWindow::refreshSerialPorts(const QString& current, bool startingUp)
 	QList<QSerialPortInfo> ports = QSerialPortInfo::availablePorts();
 	QStringList portStrings;
 	std::transform(begin(ports), end(ports), std::back_inserter(portStrings),
-				   [](QSerialPortInfo& i){ return i.portName(); });
+	               [](QSerialPortInfo& i){ return i.portName(); });
 	int chosenSerialPortIndex = -1;
 
 	if(startingUp && settings.contains(SERIAL_PORT_NAME_KEY))
@@ -357,16 +357,16 @@ void MainWindow::refreshSerialPorts(const QString& current, bool startingUp)
 
 void MainWindow::connectSerialPortComboBox() {
 	connect(ui->serialPortComboBox, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
-			picDriver, &QtPicDriver::setSerialPort);
+	        picDriver, &QtPicDriver::setSerialPort);
 	connect(ui->serialPortComboBox, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
-			this, &MainWindow::saveSerialPortPref);
+	        this, &MainWindow::saveSerialPortPref);
 }
 
 void MainWindow::disconnectSerialPortComboBox() {
 	disconnect(ui->serialPortComboBox, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
-			   picDriver, &QtPicDriver::setSerialPort);
+	           picDriver, &QtPicDriver::setSerialPort);
 	disconnect(ui->serialPortComboBox, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
-			   this, &MainWindow::saveSerialPortPref);
+	           this, &MainWindow::saveSerialPortPref);
 }
 
 void MainWindow::sendMsgButtonClicked() {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -370,13 +370,16 @@ void MainWindow::disconnectSerialPortComboBox() {
 }
 
 void MainWindow::sendMsgButtonClicked() {
+	// grab the text from the message box
+	QString text = ui->sendMsg_TextBox->text();
+
 	// if control key is not pressed, insert newline
 	if (!QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ControlModifier)) {
-		ui->sendMsg_TextBox->insert("\n");
+		text.append('\n');
 	}
 
 	// actually send the data
-	qtDataXfer.processOutboundBytes(ui->sendMsg_TextBox->text().toLocal8Bit());
+	qtDataXfer.processOutboundBytes(text.toLocal8Bit());
 
 	// clear the box if told to
 	if (ui->clearOnSendCheckBox->isChecked()) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -57,7 +57,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	connect(ui->hexFileNameEdit, &QLineEdit::textChanged, this, &MainWindow::onHexFileTextChanged);
 	connect(ui->hexFileNameEdit, &QLineEdit::textChanged, this, &MainWindow::saveHexFilePref);
 	connect(this, &MainWindow::programHexFile,
-	        picDriver, static_cast<void (QtPicDriver::*)(QString)>(&QtPicDriver::programHexFile));
+			picDriver, static_cast<void (QtPicDriver::*)(QString)>(&QtPicDriver::programHexFile));
 	connect(picDriver, &QtPicDriver::deviceChanged, ui->deviceInfoLabel, &QLabel::setText);
 	connect(picDriver, &QtPicDriver::programmingStateChanged, ui->progressWidget, &QWidget::setVisible);
 	connect(picDriver, &QtPicDriver::programmingStateChanged, ui->programmingWidget, &QWidget::setHidden);
@@ -73,7 +73,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	connect(ui->mclrButton, &StickyQButton::toggled, picDriver, &QtPicDriver::setMCLR);
 	connect(picDriver, &QtPicDriver::mclrChanged, ui->mclrButton, &StickyQButton::setChecked);
 
-    connect(ui->serialText, &InterceptQPlainTextEdit::keyPressed, [=](QString s){ qtDataXfer.processOutboundBytes(s.toLocal8Bit()); });
+	connect(ui->serialText, &InterceptQPlainTextEdit::keyPressed, [=](QString s){ qtDataXfer.processOutboundBytes(s.toLocal8Bit()); });
 	connect(&qtDataXfer, &QtDataXfer::sendRawBytes, picDriver, &QtPicDriver::sendSerialData);
 	connect(picDriver, &QtPicDriver::serialDataReceived, &qtDataXfer, &QtDataXfer::processInboundBytes);
 	connect(&qtDataXfer, &QtDataXfer::inboundBytesReady, this, &MainWindow::onSerialTextReceived);
@@ -103,8 +103,8 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	connect(ui->useDataXferCheckBox, &QAbstractButton::toggled, &qtDataXfer, &QtDataXfer::enable);
 	connect(ui->mclrButton, &StickyQButton::pressed, [=]{ ui->dataXferTable->setRowCount(0); });
 
-    connect(ui->sendMsg_TextBox, &QLineEdit::returnPressed, this, &MainWindow::sendMsgReturnPressed);
-    connect(ui->sendMsg_Button, &QAbstractButton::clicked, this, &MainWindow::sendMsgButtonClicked);
+	connect(ui->sendMsg_TextBox, &QLineEdit::returnPressed, this, &MainWindow::sendMsgReturnPressed);
+	connect(ui->sendMsg_Button, &QAbstractButton::clicked, this, &MainWindow::sendMsgButtonClicked);
 
 #ifndef NO_UPDATE_CHECK
 	connect(&checker, &GitHubUpdateChecker::updateAvailable, this, &MainWindow::onUpdateAvailable);
@@ -114,7 +114,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	// The "Monospace" suggestion won't work on Windows, which is what the StyleHint is for.
 	QFont monoFont("Monospace");
 	monoFont.setStyleHint(QFont::TypeWriter);
-    ui->serialText->setFont(std::move(monoFont));
+	ui->serialText->setFont(std::move(monoFont));
 
 	// Set up the serial port combo box.
 	// We would like to refresh every 5 seconds (or so).
@@ -124,7 +124,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	QList<qint32> bauds = QSerialPortInfo::standardBaudRates();
 	QStringList baudStrings;
 	std::transform(begin(bauds), end(bauds), std::back_inserter(baudStrings),
-	               [](qint32 baud){ QString s; s.setNum(baud); return s; });
+				   [](qint32 baud){ QString s; s.setNum(baud); return s; });
 	// Baud is always set in parser (default option is present).
 	// Because of this fact, it is difficult to determine the "most wanted"
 	// value, so we don't save this one.
@@ -150,8 +150,8 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 		checker.checkForUpdate();
 #endif
 
-    // Set the monospace font for the send message TextBox
-    ui->sendMsg_TextBox->setFont(std::move(monoFont));
+	// Set the monospace font for the send message TextBox
+	ui->sendMsg_TextBox->setFont(std::move(monoFont));
 }
 
 MainWindow::~MainWindow()
@@ -261,21 +261,21 @@ void MainWindow::refreshSerialPortsKeepCurrent()
 void MainWindow::showAbout()
 {
 	QMessageBox aboutBox(QMessageBox::NoIcon,
-	                     QStringLiteral("About BullyCPP"),
-	                     "<p align='center'>"
-	                     "<h2>BullyCPP " VERSION_STRING "</h2><br>"
-	                     "Copyright &#0169; 2014 - 2015 George Hilliard (\"thirtythreeforty\") and contributors"
-	                     "<p align='center'>"
-	                     "See <a href='https://www.github.com/thirtythreeforty/bullycpp'>www.github.com/thirtythreeforty/bullycpp</a> "
-	                     "for updates and source code."
-	                     "<p>"
-	                     "BullyCPP is a serial console and a driver for the open source Bully Bootloader for the PIC24 and dsPIC33.  "
-	                     "See <a href='http://www.reesemicro.com/'>www.reesemicro.com</a> for the microcontroller firmware."
-	                     "<p>"
-	                     "This program is free software; you can redistribute it and/or modify it under the terms of "
-	                     "the GNU General Public License v3 or later, as published by the Free Software Foundation.",
-	                     QMessageBox::Ok,
-	                     this
+						 QStringLiteral("About BullyCPP"),
+						 "<p align='center'>"
+						 "<h2>BullyCPP " VERSION_STRING "</h2><br>"
+						 "Copyright &#0169; 2014 - 2015 George Hilliard (\"thirtythreeforty\") and contributors"
+						 "<p align='center'>"
+						 "See <a href='https://www.github.com/thirtythreeforty/bullycpp'>www.github.com/thirtythreeforty/bullycpp</a> "
+						 "for updates and source code."
+						 "<p>"
+						 "BullyCPP is a serial console and a driver for the open source Bully Bootloader for the PIC24 and dsPIC33.  "
+						 "See <a href='http://www.reesemicro.com/'>www.reesemicro.com</a> for the microcontroller firmware."
+						 "<p>"
+						 "This program is free software; you can redistribute it and/or modify it under the terms of "
+						 "the GNU General Public License v3 or later, as published by the Free Software Foundation.",
+						 QMessageBox::Ok,
+						 this
 	);
 
 	aboutBox.setIconPixmap(appIcon.pixmap(128, 128));
@@ -342,7 +342,7 @@ void MainWindow::refreshSerialPorts(const QString& current, bool startingUp)
 	QList<QSerialPortInfo> ports = QSerialPortInfo::availablePorts();
 	QStringList portStrings;
 	std::transform(begin(ports), end(ports), std::back_inserter(portStrings),
-	               [](QSerialPortInfo& i){ return i.portName(); });
+				   [](QSerialPortInfo& i){ return i.portName(); });
 	int chosenSerialPortIndex = -1;
 
 	if(startingUp && settings.contains(SERIAL_PORT_NAME_KEY))
@@ -357,40 +357,40 @@ void MainWindow::refreshSerialPorts(const QString& current, bool startingUp)
 
 void MainWindow::connectSerialPortComboBox() {
 	connect(ui->serialPortComboBox, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
-	        picDriver, &QtPicDriver::setSerialPort);
+			picDriver, &QtPicDriver::setSerialPort);
 	connect(ui->serialPortComboBox, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
-	        this, &MainWindow::saveSerialPortPref);
+			this, &MainWindow::saveSerialPortPref);
 }
 
 void MainWindow::disconnectSerialPortComboBox() {
 	disconnect(ui->serialPortComboBox, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
-	           picDriver, &QtPicDriver::setSerialPort);
+			   picDriver, &QtPicDriver::setSerialPort);
 	disconnect(ui->serialPortComboBox, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
-	           this, &MainWindow::saveSerialPortPref);
+			   this, &MainWindow::saveSerialPortPref);
 }
 
 void MainWindow::sendMsgButtonClicked() {
-    // if control key is not pressed, insert newline
-    if (!QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ControlModifier)) {
-        ui->sendMsg_TextBox->insert("\n");
-    }
+	// if control key is not pressed, insert newline
+	if (!QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ControlModifier)) {
+		ui->sendMsg_TextBox->insert("\n");
+	}
 
-    // actually send the data
-    qtDataXfer.processOutboundBytes(ui->sendMsg_TextBox->text().toLocal8Bit());
+	// actually send the data
+	qtDataXfer.processOutboundBytes(ui->sendMsg_TextBox->text().toLocal8Bit());
 
-    // clear the box if told to
-    if (ui->clearOnSendCheckBox->isChecked()) {
-        ui->sendMsg_TextBox->clear();
-        ui->sendMsg_TextBox->setFocus();
-    }
+	// clear the box if told to
+	if (ui->clearOnSendCheckBox->isChecked()) {
+		ui->sendMsg_TextBox->clear();
+		ui->sendMsg_TextBox->setFocus();
+	}
 }
 
 void MainWindow::sendMsgReturnPressed() {
-    // if checked, click the button
-    // otherwise, insert a newline character
-    if (ui->sendOnReturnCheckBox->isChecked()) {
-        ui->sendMsg_Button->click();
-    } else {
-        ui->sendMsg_TextBox->insert("\n");
-    }
+	// if checked, click the button
+	// otherwise, insert a newline character
+	if (ui->sendOnReturnCheckBox->isChecked()) {
+		ui->sendMsg_Button->click();
+	} else {
+		ui->sendMsg_TextBox->insert("\n");
+	}
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -103,7 +103,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	connect(ui->useDataXferCheckBox, &QAbstractButton::toggled, &qtDataXfer, &QtDataXfer::enable);
 	connect(ui->mclrButton, &StickyQButton::pressed, [=]{ ui->dataXferTable->setRowCount(0); });
 
-	connect(ui->sendMsg_TextBox, &QLineEdit::returnPressed, this, &MainWindow::sendMsgReturnPressed);
+	connect(ui->sendMsg_TextBox, &QLineEdit::returnPressed, this, &MainWindow::sendMsgEnterPressed);
 	connect(ui->sendMsg_Button, &QAbstractButton::clicked, this, &MainWindow::sendMsgButtonClicked);
 
 #ifndef NO_UPDATE_CHECK
@@ -388,7 +388,7 @@ void MainWindow::sendMsgButtonClicked() {
 	}
 }
 
-void MainWindow::sendMsgReturnPressed() {
+void MainWindow::sendMsgEnterPressed() {
 	// if checked, click the button
 	// otherwise, insert a newline character
 	if (ui->sendOnReturnCheckBox->isChecked()) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -114,7 +114,7 @@ MainWindow::MainWindow(const QCommandLineParser& parser, QWidget* parent) :
 	// The "Monospace" suggestion won't work on Windows, which is what the StyleHint is for.
 	QFont monoFont("Monospace");
 	monoFont.setStyleHint(QFont::TypeWriter);
-	ui->serialText->setFont(std::move(monoFont));
+	ui->serialText->setFont(monoFont);
 
 	// Set up the serial port combo box.
 	// We would like to refresh every 5 seconds (or so).

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -70,8 +70,8 @@ private slots:
 	void saveMclrPref(bool);
 	void saveConfigBitsPref(bool);
 
-    void sendMsgButtonClicked();
-    void sendMsgEnterPressed();
+	void sendMsgButtonClicked();
+	void sendMsgEnterPressed();
 
 private:
 	int getPositionIfPresent(QStringList&, const QString&, int);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -70,6 +70,9 @@ private slots:
 	void saveMclrPref(bool);
 	void saveConfigBitsPref(bool);
 
+    void sendMsgButtonClicked();
+    void sendMsgReturnPressed();
+
 private:
 	int getPositionIfPresent(QStringList&, const QString&, int);
 	int addIfNotPresent(QStringList&, const QString&);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -71,7 +71,7 @@ private slots:
 	void saveConfigBitsPref(bool);
 
     void sendMsgButtonClicked();
-    void sendMsgReturnPressed();
+    void sendMsgEnterPressed();
 
 private:
 	int getPositionIfPresent(QStringList&, const QString&, int);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -382,7 +382,7 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>CTRL+SEND to omit \n append</string>
+             <string>Hold Ctrl to send without newline</string>
             </property>
             <property name="text">
              <string>Send</string>
@@ -406,7 +406,7 @@
           <item>
            <widget class="QCheckBox" name="sendOnReturnCheckBox">
             <property name="text">
-             <string>Send on ENTER</string>
+             <string>Send on Enter</string>
             </property>
             <property name="checked">
              <bool>true</bool>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -220,6 +220,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="toolTip">
+             <string>CTRL+SEND to omit \n append</string>
+            </property>
             <property name="text">
              <string>Send</string>
             </property>
@@ -242,7 +245,7 @@
           <item>
            <widget class="QCheckBox" name="sendOnReturnCheckBox">
             <property name="text">
-             <string>Send on return/enter press</string>
+             <string>Send on ENTER</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -250,20 +253,17 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
-            <property name="text">
-             <string>CTRL+SEND to omit \n append</string>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
+           </spacer>
           </item>
          </layout>
         </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -195,80 +195,6 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
-      <widget class="QWidget" name="sendMsg_Tab">
-       <attribute name="title">
-        <string>Send Message</string>
-       </attribute>
-       <layout class="QFormLayout" name="formLayout">
-        <property name="formAlignment">
-         <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-        </property>
-        <item row="0" column="0" colspan="2">
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <widget class="QLineEdit" name="sendMsg_TextBox">
-            <property name="placeholderText">
-             <string>Enter message to send</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="sendMsg_Button">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>CTRL+SEND to omit \n append</string>
-            </property>
-            <property name="text">
-             <string>Send</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0" colspan="2">
-         <layout class="QHBoxLayout" name="horizontalLayout_6">
-          <item>
-           <widget class="QCheckBox" name="clearOnSendCheckBox">
-            <property name="text">
-             <string>Clear after send</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="sendOnReturnCheckBox">
-            <property name="text">
-             <string>Send on ENTER</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_7">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
       <widget class="QWidget" name="target_programming">
        <attribute name="title">
         <string>Target Programming</string>
@@ -427,6 +353,80 @@
            </item>
           </layout>
          </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="sendMsg_Tab">
+       <attribute name="title">
+        <string>Send Message</string>
+       </attribute>
+       <layout class="QFormLayout" name="formLayout">
+        <property name="formAlignment">
+         <set>Qt::AlignBottom|Qt::AlignHCenter</set>
+        </property>
+        <item row="0" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QLineEdit" name="sendMsg_TextBox">
+            <property name="placeholderText">
+             <string>Enter message to send</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="sendMsg_Button">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>CTRL+SEND to omit \n append</string>
+            </property>
+            <property name="text">
+             <string>Send</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QCheckBox" name="clearOnSendCheckBox">
+            <property name="text">
+             <string>Clear after send</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="sendOnReturnCheckBox">
+            <property name="text">
+             <string>Send on ENTER</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -394,6 +394,19 @@
         <item row="1" column="0" colspan="2">
          <layout class="QHBoxLayout" name="horizontalLayout_6">
           <item>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
            <widget class="QCheckBox" name="clearOnSendCheckBox">
             <property name="text">
              <string>Clear after send</string>
@@ -412,19 +425,6 @@
              <bool>true</bool>
             </property>
            </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_7">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -195,6 +195,80 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
+      <widget class="QWidget" name="sendMsg_Tab">
+       <attribute name="title">
+        <string>Send Message</string>
+       </attribute>
+       <layout class="QFormLayout" name="formLayout">
+        <property name="formAlignment">
+         <set>Qt::AlignBottom|Qt::AlignHCenter</set>
+        </property>
+        <item row="0" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QLineEdit" name="sendMsg_TextBox">
+            <property name="placeholderText">
+             <string>Enter message to send</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="sendMsg_Button">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Send</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QCheckBox" name="clearOnSendCheckBox">
+            <property name="text">
+             <string>Clear after send</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="sendOnReturnCheckBox">
+            <property name="text">
+             <string>Send on return/enter press</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>CTRL+SEND to omit \n append</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="target_programming">
        <attribute name="title">
         <string>Target Programming</string>


### PR DESCRIPTION
Added an alternative way for the user to send messages (with backspace!) via serial. Instead of sending individual characters via console, this tab will send the entire message at once. 
The send automatically will append a newline (\n) character to the message, but that can be overridden by holding down CTRL and sending.